### PR TITLE
Fix CI test apt permissions and Windows TrimNativeHeap build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             -e GOCACHE=/workspace/.cache/go-build \
             -e GOMODCACHE=/workspace/.cache/go-mod \
             sqyre-linux-build \
-            bash -c 'apt-get update -qq && apt-get install -y -qq xvfb ffmpeg >/dev/null && ./scripts/test.sh && ./scripts/test-ui.sh -run "TestGUIEscape|TestDocsScreenshots|TestDemoWorkflowFrames"'
+            bash -c './scripts/test.sh && ./scripts/test-ui.sh -run "TestGUIEscape|TestDocsScreenshots|TestDemoWorkflowFrames"'
 
   build-linux:
     runs-on: ubuntu-22.04

--- a/internal/vision/native_alloc_other.go
+++ b/internal/vision/native_alloc_other.go
@@ -5,4 +5,4 @@ package vision
 // ConfigureNativeAllocator is a no-op on platforms without glibc malloc tuning.
 func ConfigureNativeAllocator() {}
 
-func TrimNativeHeap() { trimNativeHeap() }
+func TrimNativeHeap() {}


### PR DESCRIPTION
Remove runtime apt-get from the dockerized test step since xvfb is already in the image, and make TrimNativeHeap a no-op on non-Linux platforms.