### PR TITLE
fix(macro): preserve tree scroll position during drag-and-drop

### DIFF
--- a/ui/macro/tree.go
+++ b/ui/macro/tree.go
@@ -409,7 +409,9 @@ func (mt *MacroTree) Refresh() {
 	mt.Tree.Refresh()
 	if ok {
 		mt.ScrollToOffset(scrollY)
-		mt.scheduleClampScroll()
+		if !mt.dragActive {
+			mt.scheduleClampScroll()
+		}
 	}
 }
 
@@ -1052,7 +1054,7 @@ func (mt *MacroTree) setTree() {
 		mt.applyHighlightOverlay(uid, hlBg)
 	}
 	mt.Tree.OnBranchOpened = func(uid widget.TreeNodeID) {
-		if mt.suppressBranchOpenScroll > 0 {
+		if mt.suppressBranchOpenScroll > 0 || mt.dragActive {
 			return
 		}
 		target := uid
@@ -1061,6 +1063,9 @@ func (mt *MacroTree) setTree() {
 		}
 		scrollUID := target
 		fyne.Do(func() {
+			if mt.suppressBranchOpenScroll > 0 || mt.dragActive {
+				return
+			}
 			mt.ScrollTo(scrollUID)
 		})
 	}

--- a/ui/macro/tree_dnd.go
+++ b/ui/macro/tree_dnd.go
@@ -910,8 +910,10 @@ func (mt *MacroTree) applyDragPreview(key string) {
 	mt.dragPreviewKey = key
 	mt.refreshAfterDragLayout(mt.dragMutationNeedsFlush(prevParentUID, newParentUID))
 	if mt.dragSrcUID != "" {
-		mt.invalidateRowCache(mt.dragSrcUID)
-		mt.RefreshItem(mt.dragSrcUID)
+		mt.withPreservedScroll(func() {
+			mt.invalidateRowCache(mt.dragSrcUID)
+			mt.RefreshItem(mt.dragSrcUID)
+		})
 	}
 	mt.updateDropIndicator()
 }
@@ -952,8 +954,10 @@ func (mt *MacroTree) revertDragPreview() {
 	mt.dragPreviewKey = ""
 	mt.refreshAfterDragLayout(mt.dragMutationNeedsFlush(prevParentUID, originParentUID))
 	if mt.dragSrcUID != "" {
-		mt.invalidateRowCache(mt.dragSrcUID)
-		mt.RefreshItem(mt.dragSrcUID)
+		mt.withPreservedScroll(func() {
+			mt.invalidateRowCache(mt.dragSrcUID)
+			mt.RefreshItem(mt.dragSrcUID)
+		})
 	}
 }
 
@@ -1062,13 +1066,15 @@ func (mt *MacroTree) dragLayoutNeedsFlush(prevParentUID, newParentUID string) bo
 }
 
 func (mt *MacroTree) refreshAfterDragLayout(flushDepth bool) {
-	mt.suppressBranchOpenScroll++
-	if flushDepth {
-		mt.flushNodeCache()
-	} else {
-		mt.Refresh()
-	}
-	mt.suppressBranchOpenScroll--
+	mt.withPreservedScroll(func() {
+		mt.suppressBranchOpenScroll++
+		if flushDepth {
+			mt.flushNodeCache()
+		} else {
+			mt.Refresh()
+		}
+		mt.suppressBranchOpenScroll--
+	})
 	mt.dragVisible = mt.visibleRowUIDs()
 }
 
@@ -1108,7 +1114,8 @@ func (mt *MacroTree) endDrag() {
 	if !mt.dragActive {
 		return
 	}
-	mt.dragActive = false
+	dropScrollY, dropScrollOK := treeScrollOffsetY(&mt.Tree)
+
 	mt.cancelAutoExpand()
 	mt.finishDragBranchState()
 	mt.cancelDragPreviewDebounce()
@@ -1148,12 +1155,14 @@ func (mt *MacroTree) endDrag() {
 			mt.refreshAfterDragLayout(true)
 		}
 		mt.openAncestorBranches(src)
-		mt.Select(src)
+		mt.Tree.Select(widget.TreeNodeID(src))
 		mt.SelectedNode = src
 		if mt.OnTreeChanged != nil {
 			mt.OnTreeChanged()
 		}
 	}
+
+	mt.dragActive = false
 
 	mt.dragSrcUID = ""
 	mt.dropParent = nil
@@ -1168,8 +1177,13 @@ func (mt *MacroTree) endDrag() {
 	mt.dragUndoSnapshotOK = false
 
 	if src != "" {
-		mt.markHighlightRefresh(src)
-		mt.RefreshItem(src)
+		mt.withPreservedScroll(func() {
+			mt.markHighlightRefresh(src)
+			mt.RefreshItem(src)
+		})
+	}
+	if dropScrollOK {
+		mt.restoreScrollOffset(dropScrollY)
 	}
 }
 

--- a/ui/macro/tree_dnd_test.go
+++ b/ui/macro/tree_dnd_test.go
@@ -594,3 +594,12 @@ func TestResolveDrop_branchZones(t *testing.T) {
 		t.Fatalf("bottom zone mode = %v, want dropAfter", mt.dropMode)
 	}
 }
+
+func TestScheduleClampScroll_skippedDuringDrag(t *testing.T) {
+	mt, _, _, _, _ := buildDnDTree(t)
+	mt.dragActive = true
+	mt.scheduleClampScroll()
+	if !mt.dragActive {
+		t.Fatal("dragActive should remain true")
+	}
+}

--- a/ui/macro/tree_scroll.go
+++ b/ui/macro/tree_scroll.go
@@ -23,8 +23,32 @@ func clampedScrollY(contentH, viewH, currentY float32) float32 {
 
 // scheduleClampScroll runs clampScrollOffset on the next UI frame after layout.
 func (mt *MacroTree) scheduleClampScroll() {
+	if mt.dragActive {
+		return
+	}
 	fyne.Do(func() {
+		if mt.dragActive {
+			return
+		}
 		mt.clampScrollOffset()
+	})
+}
+
+// withPreservedScroll runs fn and restores the tree scroll offset afterward.
+func (mt *MacroTree) withPreservedScroll(fn func()) {
+	scrollY, ok := treeScrollOffsetY(&mt.Tree)
+	fn()
+	if ok {
+		mt.ScrollToOffset(scrollY)
+	}
+}
+
+// restoreScrollOffset sets the tree scroll position now and again on the next
+// frame so deferred layout handlers cannot override a drop-time restore.
+func (mt *MacroTree) restoreScrollOffset(scrollY float32) {
+	mt.ScrollToOffset(scrollY)
+	fyne.Do(func() {
+		mt.ScrollToOffset(scrollY)
 	})
 }
 


### PR DESCRIPTION
Skip branch-open scrolling and clamp passes while dragging, restore the drop-time scroll offset after preview refresh and selection updates.