### PR TITLE
feat(ui): dismiss modal popups with Escape via dialog wrapper

### DIFF
--- a/ui/construct.go
+++ b/ui/construct.go
@@ -60,6 +60,7 @@ func SetEditorUi() {
 		ShowErrorWithEscape:            ShowErrorWithEscape,
 		ShowConfirmWithEscape:          ShowConfirmWithEscape,
 		AddDialogEscapeClose:           AddDialogEscapeClose,
+		AddPopupEscapeClose:            AddPopupEscapeClose,
 		ShowRecordingOverlay:           recording.ShowRecordingOverlay,
 		ShowSearchAreaRecordingOverlay: recording.ShowSearchAreaRecordingOverlay,
 		WrapTagChip:                    WrapTagChip,
@@ -132,6 +133,7 @@ func SetMacroUi() {
 		},
 		ShowErrorWithEscape:   ShowErrorWithEscape,
 		AddDialogEscapeClose:  AddDialogEscapeClose,
+		AddPopupEscapeClose:   AddPopupEscapeClose,
 		ShowConfirmWithEscape: ShowConfirmWithEscape,
 		ShowActionDialog: func(action actions.ActionInterface, onSave func(actions.ActionInterface), onCancel func()) {
 			actiondialog.ShowActionDialog(action, onSave, onCancel)

--- a/ui/editor/create_dialog_wiring.go
+++ b/ui/editor/create_dialog_wiring.go
@@ -213,6 +213,7 @@ func wireItemMaskHandlers(w map[string]fyne.CanvasObject, programSelector *widge
 
 func showMaskSelectionPopupForItem(programName string, onSelect func(maskName string)) {
 	var popup *widget.PopUp
+	var hide func()
 	acc := widget.NewAccordion()
 	for _, p := range repositories.ProgramRepo().GetAllSortedByName() {
 		pName := p.Name
@@ -237,7 +238,7 @@ func showMaskSelectionPopupForItem(programName string, onSelect func(maskName st
 				return
 			}
 			onSelect(filtered[id])
-			popup.Hide()
+			hide()
 		}
 		searchbar.OnChanged = func(s string) {
 			searchDebounce.Call(func() {
@@ -263,11 +264,13 @@ func showMaskSelectionPopupForItem(programName string, onSelect func(maskName st
 			container.NewBorder(searchbar, nil, nil, nil, maskList),
 		))
 	}
-	closeButton := widget.NewButton("Close", func() { popup.Hide() })
+	closeButton := widget.NewButton("Close", func() { hide() })
 	popUpContent := container.NewBorder(closeButton, nil, nil, nil, acc)
 	popup = widget.NewModalPopUp(popUpContent, activeWire.Window.Canvas())
-	popup.Resize(fyne.NewSize(400, 500))
-	popup.Show()
+	dlg := activeWire.AddPopupEscapeClose(popup, activeWire.Window)
+	hide = dlg.Hide
+	dlg.Resize(fyne.NewSize(400, 500))
+	dlg.Show()
 }
 
 func wireCreateMaskDialog(w map[string]fyne.CanvasObject, programSelector *widget.Select, previewPanel *editorPreviewPanel, refreshBtn *widget.Button) {

--- a/ui/editor/deps.go
+++ b/ui/editor/deps.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/widget"
 
 	"Sqyre/ui/macrocxt"
 )
@@ -24,6 +25,7 @@ type WireDeps struct {
 	ShowErrorWithEscape   func(err error, parent fyne.Window)
 	ShowConfirmWithEscape func(title, message string, callback func(bool), parent fyne.Window)
 	AddDialogEscapeClose  func(d dialog.Dialog, parent fyne.Window)
+	AddPopupEscapeClose   func(pop *widget.PopUp, parent fyne.Window) dialog.Dialog
 	ShowRecordingOverlay    func(onClosed func(), onMouseDown func(*desktop.MouseEvent)) func()
 	ShowSearchAreaRecordingOverlay func(onClosed func(), onMouseDown func(*desktop.MouseEvent)) (dismiss func(), setSelectionRect func(leftX, topY, rightX, bottomY int))
 	// WrapTagChip styles tag rows in the Items tab (from ui theme helpers; avoids import cycle).

--- a/ui/editor/item_wiring.go
+++ b/ui/editor/item_wiring.go
@@ -409,6 +409,7 @@ func updateMaskDisplay(maskName string) {
 // showMaskSelectionPopup displays a modal popup with mask accordions for the user to select a mask.
 func showMaskSelectionPopup() {
 	var popup *widget.PopUp
+	var hide func()
 
 	acc := widget.NewAccordion()
 	for _, p := range repositories.ProgramRepo().GetAllSortedByName() {
@@ -454,7 +455,7 @@ func showMaskSelectionPopup() {
 
 				updateMaskDisplay(maskName)
 			}
-			popup.Hide()
+			hide()
 		}
 
 		searchbar.OnChanged = func(s string) {
@@ -483,15 +484,17 @@ func showMaskSelectionPopup() {
 		))
 	}
 
-	closeButton := widget.NewButton("Close", func() { popup.Hide() })
+	closeButton := widget.NewButton("Close", func() { hide() })
 
 	popUpContent := container.NewBorder(
 		closeButton, nil, nil, nil,
 		acc,
 	)
 	popup = widget.NewModalPopUp(popUpContent, activeWire.Window.Canvas())
-	popup.Resize(fyne.NewSize(400, 500))
-	popup.Show()
+	dlg := activeWire.AddPopupEscapeClose(popup, activeWire.Window)
+	hide = dlg.Hide
+	dlg.Resize(fyne.NewSize(400, 500))
+	dlg.Show()
 }
 
 // setMaskSelectionButtons wires up the mask select and clear buttons on the Items tab.

--- a/ui/macro/wiring.go
+++ b/ui/macro/wiring.go
@@ -31,6 +31,7 @@ type WireDeps struct {
 	ShowHotkeyRecordDialog func(parent fyne.Window, stableDuration time.Duration, onRecorded func(keys []string))
 	ShowErrorWithEscape    func(err error, parent fyne.Window)
 	AddDialogEscapeClose   func(d dialog.Dialog, parent fyne.Window)
+	AddPopupEscapeClose    func(pop *widget.PopUp, parent fyne.Window) dialog.Dialog
 	ShowConfirmWithEscape  func(title, message string, callback func(bool), parent fyne.Window)
 	ShowActionDialog       func(action actions.ActionInterface, onSave func(actions.ActionInterface), onCancel func())
 	ShowAddActionPicker    func()

--- a/ui/modal_popup_dialog.go
+++ b/ui/modal_popup_dialog.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+)
+
+// modalPopupDialog implements dialog.Dialog for widget.NewModalPopUp overlays.
+type modalPopupDialog struct {
+	pop      *widget.PopUp
+	onClosed func()
+}
+
+// WrapModalPopup returns a dialog.Dialog whose Hide dismisses the popup and runs onClosed callbacks.
+func WrapModalPopup(pop *widget.PopUp) dialog.Dialog {
+	return &modalPopupDialog{pop: pop}
+}
+
+func (d *modalPopupDialog) Show()                 { d.pop.Show() }
+func (d *modalPopupDialog) Dismiss()              { d.Hide() }
+func (d *modalPopupDialog) SetDismissText(string) {}
+func (d *modalPopupDialog) SetOnClosed(closed func()) {
+	if closed == nil {
+		return
+	}
+	orig := d.onClosed
+	d.onClosed = func() {
+		if orig != nil {
+			orig()
+		}
+		closed()
+	}
+}
+func (d *modalPopupDialog) Hide() {
+	d.pop.Hide()
+	if d.onClosed != nil {
+		cb := d.onClosed
+		d.onClosed = nil
+		cb()
+	}
+}
+func (d *modalPopupDialog) Refresh()           { d.pop.Refresh() }
+func (d *modalPopupDialog) Resize(s fyne.Size) { d.pop.Resize(s) }
+func (d *modalPopupDialog) MinSize() fyne.Size { return d.pop.MinSize() }
+
+var _ dialog.Dialog = (*modalPopupDialog)(nil)
+
+// AddPopupEscapeClose wraps a modal popup as a dialog and registers Escape to dismiss it.
+func AddPopupEscapeClose(pop *widget.PopUp, parent fyne.Window) dialog.Dialog {
+	d := WrapModalPopup(pop)
+	AddDialogEscapeClose(d, parent)
+	return d
+}

--- a/ui/modal_popup_dialog_test.go
+++ b/ui/modal_popup_dialog_test.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/widget"
+)
+
+func TestWrapModalPopup_OnClosedRunsOnHide(t *testing.T) {
+	w := test.NewWindow(widget.NewLabel("parent"))
+	t.Cleanup(w.Close)
+
+	pop := widget.NewPopUp(widget.NewLabel("popup"), w.Canvas())
+	d := WrapModalPopup(pop)
+
+	closed := false
+	d.SetOnClosed(func() { closed = true })
+	d.Hide()
+
+	if !closed {
+		t.Fatal("expected onClosed to run when dialog Hide is called")
+	}
+}


### PR DESCRIPTION
Wrap widget.NewModalPopUp overlays as dialog.Dialog so mask selection popups inherit the same Escape-to-close behavior as standard dialogs.