### PR TITLE
feat(ui): flip completion popups above when space below is tight

### DIFF
--- a/ui/completionentry/completionentry.go
+++ b/ui/completionentry/completionentry.go
@@ -6,7 +6,6 @@ package completionentry
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -106,37 +105,23 @@ func (c *CompletionEntry) onCanvas() bool {
 	return fyne.CurrentApp().Driver().CanvasForObject(c) != nil
 }
 
-// calculate the max size to make the popup to cover everything below the entry
-func (c *CompletionEntry) maxSize() fyne.Size {
-	cnv := fyne.CurrentApp().Driver().CanvasForObject(c)
-	if cnv == nil {
-		return c.Size()
-	}
-
-	if c.itemHeight == 0 {
+func (c *CompletionEntry) popupGeometry() popupGeometry {
+	measureItemHeight := func() float32 {
 		if c.navigableList == nil {
-			return c.Size()
+			return 0
 		}
 		c.itemHeight = c.navigableList.CreateItem().MinSize().Height
+		return c.itemHeight
 	}
-
-	canvasSize := cnv.Size()
-	entrySize := c.Size()
-	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c)
-	listHeight := float32(len(c.Options))*(c.itemHeight+2*theme.Padding()+theme.SeparatorThicknessSize()) + 2*theme.Padding()
-	maxHeight := canvasSize.Height - entryPos.Y - entrySize.Height - 2*theme.Padding()
-
-	if listHeight > maxHeight {
-		listHeight = maxHeight
-	}
-
-	return fyne.NewSize(entrySize.Width, listHeight)
+	return popupGeometryFor(c, len(c.Options), c.itemHeight, measureItemHeight)
 }
 
-// calculate where the popup should appear
+func (c *CompletionEntry) maxSize() fyne.Size {
+	return c.popupGeometry().size
+}
+
 func (c *CompletionEntry) popUpPos() fyne.Position {
-	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c)
-	return entryPos.Add(fyne.NewPos(0, c.Size().Height))
+	return c.popupGeometry().pos
 }
 
 // Prevent the menu to open when the user validate value from the menu.

--- a/ui/completionentry/popup_completer.go
+++ b/ui/completionentry/popup_completer.go
@@ -2,7 +2,6 @@ package completionentry
 
 import (
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -62,8 +61,9 @@ func (p *PopupCompleter) ShowLabels(options, labels []string) {
 	if p.popupMenu == nil {
 		p.popupMenu = widget.NewPopUp(p.navigableList, holder)
 	}
-	p.popupMenu.Resize(p.maxSize(holder))
-	p.popupMenu.ShowAtPosition(p.popUpPos())
+	geo := p.popupGeometry()
+	p.popupMenu.Resize(geo.size)
+	p.popupMenu.ShowAtPosition(geo.pos)
 	holder.Focus(p.navigableList)
 	p.visible = true
 }
@@ -104,22 +104,17 @@ func (p *PopupCompleter) Visible() bool {
 	return p.visible
 }
 
-func (p *PopupCompleter) maxSize(holder fyne.Canvas) fyne.Size {
-	if p.itemHeight == 0 && p.navigableList != nil {
+func (p *PopupCompleter) popupGeometry() popupGeometry {
+	count := 0
+	if p.navigableList != nil {
+		count = len(p.navigableList.items)
+	}
+	measureItemHeight := func() float32 {
+		if p.navigableList == nil {
+			return 0
+		}
 		p.itemHeight = p.navigableList.CreateItem().MinSize().Height
+		return p.itemHeight
 	}
-	hostSize := p.Host.Size()
-	hostPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(p.Host)
-	count := float32(len(p.navigableList.items))
-	listHeight := count*(p.itemHeight+2*theme.Padding()+theme.SeparatorThicknessSize()) + 2*theme.Padding()
-	maxHeight := holder.Size().Height - hostPos.Y - hostSize.Height - 2*theme.Padding()
-	if listHeight > maxHeight {
-		listHeight = maxHeight
-	}
-	return fyne.NewSize(hostSize.Width, listHeight)
-}
-
-func (p *PopupCompleter) popUpPos() fyne.Position {
-	hostPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(p.Host)
-	return hostPos.Add(fyne.NewPos(0, p.Host.Size().Height))
+	return popupGeometryFor(p.Host, count, p.itemHeight, measureItemHeight)
 }

--- a/ui/completionentry/popup_geometry.go
+++ b/ui/completionentry/popup_geometry.go
@@ -1,0 +1,57 @@
+package completionentry
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+type popupGeometry struct {
+	size fyne.Size
+	pos  fyne.Position
+}
+
+func popupGeometryFor(host fyne.CanvasObject, optionCount int, itemHeight float32, measureItemHeight func() float32) popupGeometry {
+	cnv := fyne.CurrentApp().Driver().CanvasForObject(host)
+	if cnv == nil {
+		size := host.Size()
+		return popupGeometry{size: size, pos: fyne.NewPos(0, size.Height)}
+	}
+	if itemHeight == 0 && measureItemHeight != nil {
+		itemHeight = measureItemHeight()
+	}
+	canvasSize := cnv.Size()
+	hostSize := host.Size()
+	hostPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(host)
+	padding := 2 * theme.Padding()
+
+	listHeight := float32(optionCount)*(itemHeight+2*theme.Padding()+theme.SeparatorThicknessSize()) + 2*theme.Padding()
+	spaceBelow := canvasSize.Height - hostPos.Y - hostSize.Height - padding
+	spaceAbove := hostPos.Y - padding
+	if spaceBelow < 0 {
+		spaceBelow = 0
+	}
+	if spaceAbove < 0 {
+		spaceAbove = 0
+	}
+
+	showAbove := listHeight > spaceBelow && spaceAbove > spaceBelow
+	var maxHeight float32
+	var pos fyne.Position
+	if showAbove {
+		maxHeight = spaceAbove
+		if listHeight > maxHeight {
+			listHeight = maxHeight
+		}
+		pos = fyne.NewPos(hostPos.X, hostPos.Y-listHeight)
+	} else {
+		maxHeight = spaceBelow
+		if listHeight > maxHeight {
+			listHeight = maxHeight
+		}
+		pos = hostPos.Add(fyne.NewPos(0, hostSize.Height))
+	}
+	return popupGeometry{
+		size: fyne.NewSize(hostSize.Width, listHeight),
+		pos:  pos,
+	}
+}


### PR DESCRIPTION
Extract shared popup geometry so CompletionEntry and PopupCompleter place dropdowns above the host when there is more room above than below.