### PR TITLE
Add Windows cross-build support and fix nested Docker in the devconta…

### DIFF
--- a/.cursor/rules/cross-platform.mdc
+++ b/.cursor/rules/cross-platform.mdc
@@ -1,0 +1,46 @@
+---
+description: Cross-platform Rust (conditional compilation) for Sqyre
+alwaysApply: true
+---
+
+# Cross-platform Rust
+
+When touching OS-specific code (capture, focus, overlays, trays, hotkeys), use Rust conditional compilation correctly so targets compile cleanly.
+
+## `#[cfg]` vs `cfg!`
+
+- **`#[cfg(...)]`** — compile-time inclusion; code is removed when false.
+- **`cfg!(...)`** — runtime boolean; code is still type-checked on every target.
+
+Never call platform-only APIs inside `if cfg!(...)` — use `#[cfg]` modules or blocks instead.
+
+```rust
+// CORRECT
+#[cfg(target_os = "windows")]
+fn capture() { /* Win32 */ }
+
+// WRONG — still type-checked on Linux
+fn capture() {
+    if cfg!(target_os = "windows") {
+        /* Win32 APIs fail to compile on Linux */
+    }
+}
+```
+
+## Scope imports inside cfg blocks
+
+Platform-specific imports belong inside the `#[cfg]` block or module that uses them. Do not paper over unused imports with `#[allow(unused_imports)]`.
+
+## Sqyre platform layout
+
+- **`sqyre-capture`**: Linux `x11_*`, Windows `win_*`, macOS/other stubs; public API is `OsCapturer`, `shared_capturer`, `SharedRunCapturer`, `OsWindowFocuser`.
+- **Cargo**: use `[target.'cfg(...)'.dependencies]` for OS crates (`x11`, `windows`, `tray-icon`, etc.).
+- Do not add dual codecs or compatibility shims for format changes.
+- Do not expand packaging (MSI/DMG) unless asked — Linux AppImage only for now.
+
+## Checklist
+
+- Platform imports scoped under `#[cfg]`
+- Shared traits (`ScreenCapturer`, `WindowFocuser`, `AutomationBackend`) stay OS-agnostic
+- Public names are OS-neutral (`OsCapturer`, not `X11Capturer`)
+- Prefer family predicates (`unix` / `windows`) only when behavior truly matches; Sqyre often needs `target_os = "linux"` vs `"windows"` vs `"macos"` separately

--- a/.cursor/rules/devcontainer-release-parity.mdc
+++ b/.cursor/rules/devcontainer-release-parity.mdc
@@ -1,0 +1,36 @@
+---
+description: Keep .devcontainer able to build every Linux-host release target
+alwaysApply: true
+---
+
+# Devcontainer release-build parity
+
+Whenever a **build or packaging requirement** changes (Makefile targets, Dockerfiles under `scripts/`, CI release jobs, native libs, linkers, tessdata, cargo features for release binaries), update [`.devcontainer/`](.devcontainer/) so the container can still produce every release artifact that is meant to be built from Linux.
+
+## Releases the container must support
+
+| Target | How |
+|--------|-----|
+| `make` / `make release` | Native in-container (Rust + system Tesseract/X11) |
+| `make appimage` | Native AppImage tools in the image, or Docker fallback |
+| `make windows` | Docker MinGW cross (`scripts/windows/`) via **host Docker socket** |
+
+`make macos` stays macOS-host-only — do not claim the Linux devcontainer builds it.
+
+## When you change builds
+
+1. Add any new host packages / tools to [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile) (or document why they only live in a nested build image).
+2. If a target needs Docker (`make windows`, AppImage Docker fallback), keep the **docker-outside-of-docker** feature (or equivalent CLI + `/var/run/docker.sock`) in [`devcontainer.json`](.devcontainer/devcontainer.json).
+3. Keep nested images self-contained ([`scripts/windows/Dockerfile`](scripts/windows/Dockerfile), AppImage path) — the outer container only needs the Docker client + enough deps for native Linux builds.
+4. Update [`docs/DEVELOPING.md`](docs/DEVELOPING.md) if the developer workflow changes.
+5. Smoke-check from the container mindset: `make release`, `make appimage` (or its Docker path), `make windows` must remain reachable.
+
+## Examples
+
+```
+❌ Add make windows MinGW image but leave the container without Docker CLI/socket
+✅ Feature docker-outside-of-docker + scripts/windows/Dockerfile for the toolchain
+
+❌ New release link dep only in CI workflow
+✅ Same package (or documented nested image) in .devcontainer/Dockerfile
+```

--- a/.cursor/rules/idiomatic-rust.mdc
+++ b/.cursor/rules/idiomatic-rust.mdc
@@ -1,0 +1,42 @@
+---
+description: Idiomatic Rust language ergonomics (Option/Result, ownership, enums)
+globs: "**/*.rs"
+alwaysApply: false
+---
+
+# Idiomatic Rust
+
+Write concise Rust that uses the type system and std combinators — not patterns from other languages.
+
+## Option / Result
+
+- Prefer `?`, `map`, `and_then`, `ok_or`, and iterator adapters over nested `match`/`if let` when the flow stays clear
+- Library and app logic return `Result` with `thiserror` types; do not invent parallel error crates
+- `unwrap` / `expect` only in tests or genuinely unreachable paths (document why with `expect("…")`)
+
+```rust
+// ❌
+if let Some(x) = opt {
+    match f(x) {
+        Ok(v) => Some(v),
+        Err(_) => None,
+    }
+} else {
+    None
+}
+
+// ✅
+opt.and_then(|x| f(x).ok())
+```
+
+## Ownership at boundaries
+
+- Take `&str` / `impl AsRef<str>` / `impl AsRef<Path>` when you only read
+- Return / store `String` / `PathBuf` when you need ownership
+- Do not use out-parameters — return values instead
+
+## Clarity
+
+- Prefer enums over `bool` (or pairs of bools) when states are distinct modes
+- Keep bindings immutable by default; use `mut` only where mutation is required
+- Prefer iterators over index loops when they are clearer and equally efficient

--- a/.cursor/rules/rust-api-design.mdc
+++ b/.cursor/rules/rust-api-design.mdc
@@ -1,0 +1,38 @@
+---
+description: Rust API Guidelines for public types and conversions
+globs: "**/*.rs"
+alwaysApply: false
+---
+
+# Rust API Design
+
+Follow the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) for types other crates or modules call into.
+
+## Naming
+
+- Conversions: `as_` (cheap/borrowed), `to_` (expensive/owned copy), `into_` (consuming)
+- Getters: bare field name (`width()`), not `get_width()`, unless needed to avoid clashes
+- Iterators: `iter` / `iter_mut` / `into_iter`
+
+## Conversions and traits
+
+- Prefer `From` / `TryFrom` / `AsRef` / `AsMut` over one-off conversion helpers
+- Error types: meaningful `thiserror` enums with `Display` + `Error`; no `String`/`anyhow` in library crates
+- Derive or implement common traits when they make sense (`Debug`, `Clone`, `PartialEq`, …)
+
+```rust
+// ❌
+fn to_path(s: &str) -> PathBuf { PathBuf::from(s) }
+
+// ✅
+impl From<&str> for MyPath {
+    fn from(s: &str) -> Self { Self(PathBuf::from(s)) }
+}
+```
+
+## Type safety
+
+- Use newtypes for domain distinctions (IDs, units, validated strings)
+- Prefer dedicated enums/structs over `bool` / `Option` soup in public parameters
+- Constructors are inherent associated functions (`Type::new` / `Type::with_…`)
+- Return values; do not take `&mut out` parameters for results

--- a/.cursor/rules/rust-clippy-safety.mdc
+++ b/.cursor/rules/rust-clippy-safety.mdc
@@ -1,0 +1,32 @@
+---
+description: Clippy compliance and safe unsafe usage
+globs: "**/*.rs"
+alwaysApply: false
+---
+
+# Clippy and Safety
+
+CI runs `make clippy` with `-D warnings`. Treat Clippy failures as bugs to fix, not noise to silence.
+
+## Clippy
+
+- Fix warnings at the source; prefer refactoring over `#[allow(clippy::…)]`
+- If an allow is unavoidable, put it on the smallest item and add a one-line reason
+- Do not weaken workspace lint policy in `Cargo.toml` to land a change
+
+## Unsafe
+
+- Prefer safe APIs; introduce `unsafe` only when required for FFI or proven invariants
+- Every `unsafe` block needs a `// SAFETY:` comment stating the invariant that makes it sound
+- Do not expand `unsafe` to “make the borrow checker happy” when restructuring ownership would work
+
+```rust
+// ✅
+// SAFETY: `ptr` was allocated by `alloc` in this module and is aligned for `T`.
+let val = unsafe { ptr.read() };
+```
+
+## Concurrency pitfalls
+
+- Do not hold a mutex/guard across `.await` or long work inside `if let` / `match` arms that keep the guard alive
+- Drop or scope guards explicitly when the critical section ends

--- a/.cursor/rules/rust-development.mdc
+++ b/.cursor/rules/rust-development.mdc
@@ -5,7 +5,9 @@ alwaysApply: true
 
 # Rust Development
 
-This repo is a Rust Cargo workspace (Linux/X11 + egui). Do not add a second implementation language or dual-build stacks.
+This repo is a Rust Cargo workspace (egui desktop). Do not add a second implementation language or dual-build stacks.
+
+**Platforms:** Linux/X11 is the shipped desktop path. Windows and macOS are in progress (capture on Windows; focus/outline/macOS capture still stubbed). Prefer extending existing `#[cfg]` modules over inventing parallel stacks.
 
 ## Layout
 
@@ -19,23 +21,28 @@ This repo is a Rust Cargo workspace (Linux/X11 + egui). Do not add a second impl
 
 Prefer Makefile targets when they exist:
 
-- `make` / `make sqyre` — debug build → `./bin/sqyre`
-- `make release` — release build
+- `make` / `make sqyre` — debug build → `./bin/sqyre` (`.exe` on Windows)
+- `make release` — host release build → `./bin/sqyre`
+- `make windows` / `make macos` — Windows via Docker MinGW cross (or native on Windows); macOS host-only (no MSI/DMG)
+- Devcontainer must stay able to build Linux-host releases (`release`, `appimage`, `windows`) — see `devcontainer-release-parity`
 - `make test` — workspace tests
 - `make run` — `cargo run -p sqyre-app`
 - `make tessdata` — download OCR data
-- `make appimage` — Linux AppImage
+- `make appimage` — Linux AppImage (only packaging path until Win/mac installers exist)
 - `make docs-media` — regenerate README screenshots under `docs/images/`
 
 Direct cargo is fine: `cargo build -p sqyre-app`, `cargo test -p <crate>`.
 
 ## Code style
 
-- Prefer idiomatic Rust
+- Follow `idiomatic-rust`, `rust-api-design`, and `rust-clippy-safety` when editing Rust
 - Do not add compatibility shims or dual codecs unless the user asks
 - Keep breaking changes clean (see no-backwards-compatibility rule)
-- Linux/X11 + egui is the supported desktop path; don’t invent Windows/macOS support unprompted
+- Use `#[cfg(target_os = "...")]` modules for OS APIs (not `cfg!()` with platform types); scope platform imports inside those blocks
+- Keep one public capture/focus surface (`OsCapturer`, `shared_capturer`, `OsWindowFocuser`) across targets
+
 
 ## Out of scope unless asked
 
 - Flatpak or Nix packaging (removed; AppImage only)
+- MSI/DMG or other Win/mac installers

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
 # Rust Sqyre workspace (egui / PureCV / Tesseract) + AppImage packaging tools.
+# Also used as the Linux AppImage Docker build image (make appimage fallback / CI).
+# Docker CLI comes from the docker-outside-of-docker feature (host daemon via socket)
+# so `make windows` and nested AppImage builds work inside the container.
 # Build and test in-container; run the GUI binary on the host (needs X11).
 FROM ubuntu:22.04
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,17 @@
   "mounts": [
     "source=sqyre-cargo-home,target=/home/vscode/.cargo,type=volume"
   ],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false,
+      "installDockerBuildx": true
+    }
+  },
   "containerEnv": {
     "CARGO_HOME": "/home/vscode/.cargo",
     "RUSTUP_HOME": "/usr/local/rustup",
-    "CARGO_TARGET_DIR": "/workspace/target"
+    "CARGO_TARGET_DIR": "/workspace/target",
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
   },
   "customizations": {
     "vscode": {
@@ -21,7 +28,7 @@
       ]
     }
   },
-  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.cargo 2>/dev/null || true && rustup component add rust-src 2>/dev/null || true && rustc --version && cargo --version && cargo fetch",
+  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.cargo 2>/dev/null || true && rustup component add rust-src 2>/dev/null || true && rustc --version && cargo --version && (docker version >/dev/null && echo 'docker: ok' || echo 'docker: unavailable (need host Docker + rebuild)') && cargo fetch",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
-# Build and release Sqyre on merge to main (Linux Rust only).
-# Produces: Linux binary, AppImage.
+# Build and release Sqyre on merge to main.
+# Releases: Linux binary + AppImage only.
+# Also compile-checks Windows (GDI capture) and macOS (stub capture) on PRs/pushes.
 # Release tag / artifact names: vYYYY.MM.DD.HHMM (e.g. v2026.03.03.1643).
 
 name: Build and Release
@@ -148,6 +149,65 @@ jobs:
             target/coverage/lcov.info
           if-no-files-found: warn
           retention-days: 14
+
+  check-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Install LLVM (bindgen) and pkg-config
+        run: choco install llvm pkgconfiglite -y
+
+      - name: Install leptonica and tesseract (vcpkg)
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install leptonica:x64-windows tesseract:x64-windows
+
+      - name: Cache Cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: cargo check (sqyre-app)
+        env:
+          LIBCLANG_PATH: C:\Program Files\LLVM\bin
+        run: |
+          $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
+          $env:PKG_CONFIG_PATH = "$($env:VCPKG_INSTALLATION_ROOT)\installed\x64-windows\lib\pkgconfig"
+          cargo check -p sqyre-app
+
+  check-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.92.0
+
+      - name: Install Tesseract / Leptonica
+        run: brew install tesseract leptonica
+
+      - name: Cache Cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: cargo check (sqyre-app)
+        run: cargo check -p sqyre-app
 
   build-linux:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3818,6 +3818,7 @@ dependencies = [
  "parking_lot",
  "sqyre-executor",
  "thiserror 2.0.18",
+ "windows",
  "x11",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Sqyre build helpers. Default output: ./bin
 # Binary is Rust (sqyre-app). Linux AppImage packaging uses the same stack.
-.PHONY: all sqyre release test coverage check check-fmt fmt clippy deny machete \
+# Windows: Docker MinGW cross from Linux (scripts/windows/), or native on Windows.
+.PHONY: all sqyre release windows macos test coverage check check-fmt fmt clippy deny machete \
 	run tessdata appimage docs-media help
 
 ROOT := $(abspath .)
@@ -10,6 +11,33 @@ CARGO ?= cargo
 CARGO_FLAGS ?=
 # Honor CARGO_TARGET_DIR when set (CI / sandbox); otherwise ./target
 TARGET_DIR := $(if $(CARGO_TARGET_DIR),$(CARGO_TARGET_DIR),$(ROOT)/target)
+
+# Host OS for native binary targets (Windows_NT / Darwin / Linux / MinGW / MSYS).
+ifeq ($(OS),Windows_NT)
+  HOST_OS := windows
+  BIN_EXT := .exe
+else
+  UNAME_S := $(shell uname -s 2>/dev/null)
+  ifeq ($(UNAME_S),Darwin)
+    HOST_OS := macos
+    BIN_EXT :=
+  else ifeq ($(UNAME_S),Linux)
+    HOST_OS := linux
+    BIN_EXT :=
+  else ifneq (,$(findstring MINGW,$(UNAME_S)))
+    HOST_OS := windows
+    BIN_EXT := .exe
+  else ifneq (,$(findstring MSYS,$(UNAME_S)))
+    HOST_OS := windows
+    BIN_EXT := .exe
+  else ifneq (,$(findstring CYGWIN,$(UNAME_S)))
+    HOST_OS := windows
+    BIN_EXT := .exe
+  else
+    HOST_OS := unknown
+    BIN_EXT :=
+  endif
+endif
 
 # Prefer env/devcontainer cargo; fall back to workspace-local toolchain on the host.
 # Docker/CI use .cache/cargo (or inherit CARGO_HOME when Make exports .cargo-home).
@@ -31,8 +59,11 @@ all: sqyre
 
 help:
 	@echo "Targets:"
-	@echo "  all / sqyre  - cargo build (debug) -> $(BIN)/sqyre  [default]"
-	@echo "  release      - cargo build --release -> $(BIN)/sqyre"
+	@echo "  all / sqyre  - cargo build (debug) -> $(BIN)/sqyre$(BIN_EXT)  [default]"
+	@echo "  release      - cargo build --release -> $(BIN)/sqyre$(BIN_EXT)"
+	@echo "  windows      - Windows release -> $(BIN)/sqyre.exe"
+	@echo "                 (Docker MinGW cross on Linux; native on Windows)"
+	@echo "  macos        - native macOS release -> $(BIN)/sqyre  (macOS host)"
 	@echo "  test         - cargo nextest (fallback: cargo test)"
 	@echo "  check-fmt    - cargo fmt --check"
 	@echo "  fmt          - cargo fmt --all (write)"
@@ -52,9 +83,21 @@ $(BIN):
 
 sqyre: $(BIN)
 	$(CARGO) build -p sqyre-app $(CARGO_FLAGS)
-	cp -f $(TARGET_DIR)/debug/sqyre $(BIN)/sqyre
+	cp -f $(TARGET_DIR)/debug/sqyre$(BIN_EXT) $(BIN)/sqyre$(BIN_EXT)
 
 release: $(BIN)
+	$(CARGO) build -p sqyre-app --release $(CARGO_FLAGS)
+	cp -f $(TARGET_DIR)/release/sqyre$(BIN_EXT) $(BIN)/sqyre$(BIN_EXT)
+
+# Windows release binary (no MSI). Docker MinGW cross from Linux; native on Windows.
+windows: $(BIN)
+	./scripts/windows/build.sh
+
+macos: $(BIN)
+	@if [ "$(HOST_OS)" != "macos" ]; then \
+		echo "make macos requires a macOS host (got $(HOST_OS))"; \
+		exit 1; \
+	fi
 	$(CARGO) build -p sqyre-app --release $(CARGO_FLAGS)
 	cp -f $(TARGET_DIR)/release/sqyre $(BIN)/sqyre
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Sqyre lets you build and run macros without writing code. Each macro is a tree of actions: loops and branches for flow control, detection steps when the screen matters, and leaf actions for concrete input. Macros, images, masks, and data tables live under **`~/.sqyre/`** (config in `db.yaml`).
 
-**Platforms:** Linux X11 (primary). Windows/macOS automation is not shipped yet.
+**Platforms:** Linux X11 (shipped). Windows screen capture is in progress; macOS capture/focus and Win/macOS releases are not shipped yet.
 
 ---
 
@@ -67,6 +67,7 @@ Assets under `docs/images/` are generated from in-memory egui tests (`make docs-
 | Linux binary (default) | `make` / `make sqyre` → `./bin/sqyre` |
 | Run without installing | `make run` |
 | Release binary | `make release` |
+| Windows / macOS native | `make windows` → `./bin/sqyre.exe` (Docker cross on Linux) · `make macos` → `./bin/sqyre` |
 | AppImage | `make appimage` |
 | Tests | `make test` |
 | README screenshots | `make docs-media` |

--- a/crates/sqyre-app/src/app_run.rs
+++ b/crates/sqyre-app/src/app_run.rs
@@ -4,7 +4,7 @@ use crate::app_backends::{trim_process_heap, AppOcr, BridgeContinueWait, StopWat
 use crate::catalog::{CatalogIcons, CatalogResolver, SnapshotMacros};
 use crate::SqyreApp;
 use eframe::egui;
-use sqyre_capture::{shared_capturer, SharedRunCapturer, X11WindowFocuser};
+use sqyre_capture::{shared_capturer, OsWindowFocuser, SharedRunCapturer};
 use sqyre_domain::Macro;
 use sqyre_executor::{execute_macro_with, ExecDeps, OcrEngine};
 use sqyre_input::OsAutomation;
@@ -76,7 +76,7 @@ impl SqyreApp {
                 let mut capturer = SharedRunCapturer(capturer_arc);
                 let resolver = CatalogResolver(&catalog);
                 let icons = CatalogIcons(&catalog);
-                let focuser = X11WindowFocuser;
+                let focuser = OsWindowFocuser;
                 let ocr_engine = LeptessOcr::from_env_or_system()
                     .map_err(|e| {
                         eprintln!("sqyre: {e}");

--- a/crates/sqyre-app/src/preview_tooltip.rs
+++ b/crates/sqyre-app/src/preview_tooltip.rs
@@ -2,7 +2,7 @@
 
 use eframe::egui::{self, ColorImage, TextureHandle, TextureOptions, Vec2};
 use image::{Rgba, RgbaImage};
-use sqyre_capture::{shared_capturer, X11Capturer};
+use sqyre_capture::{shared_capturer, OsCapturer};
 use sqyre_domain::{Action, ActionKind, CoordinateRef, Macro, ScalarValue};
 use sqyre_executor::DesktopRect;
 use sqyre_persist::{ProgramCatalog, ProgramPoint, ProgramSearchArea};
@@ -51,7 +51,7 @@ struct PendingCapture {
 /// Lazy capturer + LRU texture cache for coordinate preview tooltips.
 #[derive(Default)]
 pub struct PreviewTooltipCache {
-    capturer: Option<Arc<X11Capturer>>,
+    capturer: Option<Arc<OsCapturer>>,
     capturer_failed: bool,
     entries: HashMap<String, CacheEntry>,
     order: Vec<String>,
@@ -374,7 +374,7 @@ enum PreviewCoords {
     },
 }
 
-fn capture_preview(capturer: &X11Capturer, coords: PreviewCoords) -> Result<RgbaImage, String> {
+fn capture_preview(capturer: &OsCapturer, coords: PreviewCoords) -> Result<RgbaImage, String> {
     let vb = capturer.virtual_bounds_ref()?;
     match coords {
         PreviewCoords::Point { x, y } => {

--- a/crates/sqyre-capture/Cargo.toml
+++ b/crates/sqyre-capture/Cargo.toml
@@ -3,7 +3,7 @@ name = "sqyre-capture"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
-description = "ScreenCapturer for absolute virtual-desktop rects (Linux X11 first)"
+description = "ScreenCapturer for absolute virtual-desktop rects (Linux X11; Windows GDI; macOS stub)"
 
 [lints]
 workspace = true
@@ -16,5 +16,12 @@ parking_lot = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [dev-dependencies]

--- a/crates/sqyre-capture/src/error.rs
+++ b/crates/sqyre-capture/src/error.rs
@@ -4,18 +4,20 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum CaptureError {
-    #[error("XOpenDisplay failed (need X11, not Wayland-only)")]
+    #[error("open display failed (need a graphical session)")]
     OpenDisplay,
-    #[error("XQueryPointer failed")]
+    #[error("query pointer failed")]
     QueryPointer,
     #[error("empty capture rect")]
     EmptyRect,
-    #[error("XGetImage failed for {x},{y},{w},{h}")]
+    #[error("capture failed for {x},{y},{w},{h}")]
     GetImage { x: i32, y: i32, w: i32, h: i32 },
     #[error("unexpected bits_per_pixel {0}")]
     BitsPerPixel(i32),
-    #[error("X11Capturer: only display 0 supported for now (got {0})")]
+    #[error("OsCapturer: only display 0 supported for now (got {0})")]
     UnsupportedDisplay(i32),
+    #[error("GDI: {0}")]
+    Gdi(String),
     #[error("mutex poisoned: {0}")]
     Mutex(String),
     #[error("{0}")]

--- a/crates/sqyre-capture/src/lib.rs
+++ b/crates/sqyre-capture/src/lib.rs
@@ -6,6 +6,8 @@ mod error;
 mod outline_stub;
 mod pixel_convert;
 mod stub;
+#[cfg(target_os = "windows")]
+mod win_capture;
 #[cfg(target_os = "linux")]
 mod x11_capture;
 #[cfg(target_os = "linux")]
@@ -24,10 +26,13 @@ pub use pixel_convert::{zpixmap_to_rgb, zpixmap_to_rgba};
 pub use stub::{NullCapturer, SolidCapturer};
 
 #[cfg(target_os = "linux")]
-pub use x11_capture::{shared_capturer, SharedRunCapturer, X11Capturer};
+pub use x11_capture::{shared_capturer, OsCapturer, SharedRunCapturer};
+
+#[cfg(target_os = "windows")]
+pub use win_capture::{shared_capturer, OsCapturer, SharedRunCapturer};
 
 #[cfg(target_os = "linux")]
-pub use x11_focus::X11WindowFocuser;
+pub use x11_focus::OsWindowFocuser;
 
 #[cfg(target_os = "linux")]
 pub use x11_outline::{OutlineRect, SelectionOutline};
@@ -41,18 +46,19 @@ pub fn owns_secondary_x_display(display: *mut std::ffi::c_void) -> bool {
 #[cfg(not(target_os = "linux"))]
 pub use outline_stub::{OutlineRect, SelectionOutline};
 
-#[cfg(not(target_os = "linux"))]
-pub type X11Capturer = NullCapturer;
+/// macOS / other: capture not implemented yet.
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub type OsCapturer = NullCapturer;
 
-#[cfg(not(target_os = "linux"))]
-pub fn shared_capturer() -> Result<std::sync::Arc<X11Capturer>, String> {
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub fn shared_capturer() -> Result<std::sync::Arc<OsCapturer>, String> {
     Err("screen capture: not supported on this platform".into())
 }
 
-#[cfg(not(target_os = "linux"))]
-pub struct SharedRunCapturer(pub std::sync::Arc<X11Capturer>);
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub struct SharedRunCapturer(pub std::sync::Arc<OsCapturer>);
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 impl sqyre_executor::ScreenCapturer for SharedRunCapturer {
     fn capture_monitor(&mut self, _display_index: i32) -> Result<image::RgbaImage, String> {
         Err("screen capture: not supported on this platform".into())
@@ -270,13 +276,13 @@ pub fn window_matches_binding(win: &WindowInfo, process_path: &str, window_title
     window_matches_process(win, process_path) && window_matches_title(win, window_title)
 }
 
-/// No-op focuser for non-Linux (or tests without a display).
+/// Stub focuser when OS window activation is not implemented.
 #[cfg(not(target_os = "linux"))]
 #[derive(Debug, Default, Clone, Copy)]
-pub struct X11WindowFocuser;
+pub struct OsWindowFocuser;
 
 #[cfg(not(target_os = "linux"))]
-impl sqyre_executor::WindowFocuser for X11WindowFocuser {
+impl sqyre_executor::WindowFocuser for OsWindowFocuser {
     fn focus(&self, _process_path: &str, _window_title: &str) -> Result<(), String> {
         Err("focus window: not supported on this platform".into())
     }

--- a/crates/sqyre-capture/src/win_capture.rs
+++ b/crates/sqyre-capture/src/win_capture.rs
@@ -1,0 +1,291 @@
+//! Windows GDI absolute virtual-desktop capture.
+
+use crate::error::CaptureError;
+use image::RgbaImage;
+use parking_lot::Mutex;
+use sqyre_executor::{DesktopRect, RgbCapture, ScreenCapturer};
+use std::sync::{Arc, OnceLock};
+use windows::core::BOOL;
+use windows::Win32::Foundation::{LPARAM, RECT};
+use windows::Win32::Graphics::Gdi::{
+    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
+    EnumDisplayMonitors, GetDC, GetDIBits, ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER,
+    DIB_RGB_COLORS, HDC, HGDIOBJ, HMONITOR, SRCCOPY,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+};
+
+/// Shared GDI desktop capture (serialized via mutex).
+pub struct OsCapturer {
+    inner: Mutex<()>,
+}
+
+/// Process-wide capturer for UI offload (cloned via [`Arc`]; access serialized by inner Mutex).
+static SHARED_UI_CAPTURER: OnceLock<Result<Arc<OsCapturer>, String>> = OnceLock::new();
+
+/// Shared capturer for UI-thread offload (preview tooltips, AutoPic, etc.).
+pub fn shared_capturer() -> Result<Arc<OsCapturer>, String> {
+    match SHARED_UI_CAPTURER
+        .get_or_init(|| OsCapturer::open().map(Arc::new).map_err(|e| e.to_string()))
+    {
+        Ok(c) => Ok(Arc::clone(c)),
+        Err(e) => Err(e.clone()),
+    }
+}
+
+impl OsCapturer {
+    pub fn open() -> Result<Self, CaptureError> {
+        let vb = virtual_screen_metrics()?;
+        if vb.w <= 0 || vb.h <= 0 {
+            return Err(CaptureError::OpenDisplay);
+        }
+        Ok(Self {
+            inner: Mutex::new(()),
+        })
+    }
+
+    /// Capture a desktop rect (`&self` — safe to call via [`Arc`] from worker threads).
+    pub fn capture_rect_ref(&self, rect: DesktopRect) -> Result<RgbaImage, String> {
+        let _guard = self.inner.lock();
+        capture_rect_gdi(rect)
+    }
+
+    /// Capture RGB directly (no alpha channel / no second conversion pass).
+    pub fn capture_rect_rgb_ref(&self, rect: DesktopRect) -> Result<RgbCapture, String> {
+        let _guard = self.inner.lock();
+        let rgba = capture_rect_gdi(rect)?;
+        Ok(RgbCapture::from_rgba(&rgba))
+    }
+
+    /// Virtual desktop bounds (`&self`).
+    pub fn virtual_bounds_ref(&self) -> Result<DesktopRect, String> {
+        let _guard = self.inner.lock();
+        virtual_screen_metrics().map_err(Into::into)
+    }
+
+    /// Monitor sizes (`&self`).
+    pub fn monitor_sizes_ref(&self) -> Result<Vec<(i32, i32)>, String> {
+        let _guard = self.inner.lock();
+        enum_monitor_sizes().map_err(Into::into)
+    }
+}
+
+impl ScreenCapturer for OsCapturer {
+    fn capture_monitor(&mut self, display_index: i32) -> Result<RgbaImage, String> {
+        if display_index != 0 {
+            return Err(CaptureError::UnsupportedDisplay(display_index).into());
+        }
+        let vb = self.virtual_bounds_ref()?;
+        self.capture_rect_ref(vb)
+    }
+
+    fn capture_rect(&mut self, rect: DesktopRect) -> Result<RgbaImage, String> {
+        self.capture_rect_ref(rect)
+    }
+
+    fn capture_rect_rgb(&mut self, rect: DesktopRect) -> Result<RgbCapture, String> {
+        self.capture_rect_rgb_ref(rect)
+    }
+
+    fn virtual_bounds(&mut self) -> Result<DesktopRect, String> {
+        self.virtual_bounds_ref()
+    }
+
+    fn monitor_sizes(&mut self) -> Result<Vec<(i32, i32)>, String> {
+        self.monitor_sizes_ref()
+    }
+}
+
+/// [`ScreenCapturer`] over a shared [`Arc`] capturer (macro run thread).
+pub struct SharedRunCapturer(pub Arc<OsCapturer>);
+
+impl ScreenCapturer for SharedRunCapturer {
+    fn capture_monitor(&mut self, display_index: i32) -> Result<RgbaImage, String> {
+        if display_index != 0 {
+            return Err(CaptureError::UnsupportedDisplay(display_index).into());
+        }
+        let vb = self.0.virtual_bounds_ref()?;
+        self.0.capture_rect_ref(vb)
+    }
+
+    fn capture_rect(&mut self, rect: DesktopRect) -> Result<RgbaImage, String> {
+        self.0.capture_rect_ref(rect)
+    }
+
+    fn capture_rect_rgb(&mut self, rect: DesktopRect) -> Result<RgbCapture, String> {
+        self.0.capture_rect_rgb_ref(rect)
+    }
+
+    fn virtual_bounds(&mut self) -> Result<DesktopRect, String> {
+        self.0.virtual_bounds_ref()
+    }
+
+    fn monitor_sizes(&mut self) -> Result<Vec<(i32, i32)>, String> {
+        self.0.monitor_sizes_ref()
+    }
+}
+
+fn virtual_screen_metrics() -> Result<DesktopRect, CaptureError> {
+    unsafe {
+        let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        let w = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        let h = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        if w <= 0 || h <= 0 {
+            return Err(CaptureError::OpenDisplay);
+        }
+        Ok(DesktopRect { x, y, w, h })
+    }
+}
+
+fn capture_rect_gdi(rect: DesktopRect) -> Result<RgbaImage, String> {
+    if rect.is_empty() {
+        return Err(CaptureError::EmptyRect.into());
+    }
+    let w = rect.w as u32;
+    let h = rect.h as u32;
+
+    unsafe {
+        let screen_dc = GetDC(None);
+        if screen_dc.is_invalid() {
+            return Err(CaptureError::Gdi("GetDC failed".into()).into());
+        }
+
+        let mem_dc = CreateCompatibleDC(Some(screen_dc));
+        if mem_dc.is_invalid() {
+            ReleaseDC(None, screen_dc);
+            return Err(CaptureError::Gdi("CreateCompatibleDC failed".into()).into());
+        }
+
+        let bitmap = CreateCompatibleBitmap(screen_dc, rect.w, rect.h);
+        if bitmap.is_invalid() {
+            let _ = DeleteDC(mem_dc);
+            ReleaseDC(None, screen_dc);
+            return Err(CaptureError::Gdi("CreateCompatibleBitmap failed".into()).into());
+        }
+
+        let old = SelectObject(mem_dc, HGDIOBJ::from(bitmap));
+        let blit_ok = BitBlt(
+            mem_dc,
+            0,
+            0,
+            rect.w,
+            rect.h,
+            Some(screen_dc),
+            rect.x,
+            rect.y,
+            SRCCOPY,
+        );
+        if blit_ok.is_err() {
+            SelectObject(mem_dc, old);
+            let _ = DeleteObject(HGDIOBJ::from(bitmap));
+            let _ = DeleteDC(mem_dc);
+            ReleaseDC(None, screen_dc);
+            return Err(CaptureError::GetImage {
+                x: rect.x,
+                y: rect.y,
+                w: rect.w,
+                h: rect.h,
+            }
+            .into());
+        }
+
+        let mut bmi = BITMAPINFO {
+            bmiHeader: BITMAPINFOHEADER {
+                biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                biWidth: rect.w,
+                biHeight: -rect.h, // top-down
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: 0, // BI_RGB
+                biSizeImage: 0,
+                biXPelsPerMeter: 0,
+                biYPelsPerMeter: 0,
+                biClrUsed: 0,
+                biClrImportant: 0,
+            },
+            bmiColors: [Default::default()],
+        };
+
+        let mut bgra = vec![0u8; (w as usize).saturating_mul(h as usize).saturating_mul(4)];
+        let lines = GetDIBits(
+            mem_dc,
+            bitmap,
+            0,
+            h,
+            Some(bgra.as_mut_ptr().cast()),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+
+        SelectObject(mem_dc, old);
+        let _ = DeleteObject(HGDIOBJ::from(bitmap));
+        let _ = DeleteDC(mem_dc);
+        ReleaseDC(None, screen_dc);
+
+        if lines == 0 {
+            return Err(CaptureError::GetImage {
+                x: rect.x,
+                y: rect.y,
+                w: rect.w,
+                h: rect.h,
+            }
+            .into());
+        }
+
+        // BGRA → RGBA
+        for pixel in bgra.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+            pixel[3] = 255;
+        }
+
+        RgbaImage::from_raw(w, h, bgra)
+            .ok_or_else(|| CaptureError::Message("invalid RGBA buffer".into()).into())
+    }
+}
+
+fn enum_monitor_sizes() -> Result<Vec<(i32, i32)>, CaptureError> {
+    let mut sizes: Vec<(i32, i32)> = Vec::new();
+    unsafe {
+        let ok = EnumDisplayMonitors(
+            None,
+            None,
+            Some(monitor_enum_proc),
+            LPARAM(&mut sizes as *mut Vec<(i32, i32)> as isize),
+        );
+        if !ok.as_bool() || sizes.is_empty() {
+            let vb = virtual_screen_metrics()?;
+            return Ok(vec![(vb.w, vb.h)]);
+        }
+    }
+    Ok(sizes)
+}
+
+unsafe extern "system" fn monitor_enum_proc(
+    _monitor: HMONITOR,
+    _hdc: HDC,
+    lprc: *mut RECT,
+    lparam: LPARAM,
+) -> BOOL {
+    let sizes = &mut *(lparam.0 as *mut Vec<(i32, i32)>);
+    if !lprc.is_null() {
+        let r = *lprc;
+        let w = r.right - r.left;
+        let h = r.bottom - r.top;
+        if w > 0 && h > 0 {
+            sizes.push((w, h));
+        }
+    }
+    BOOL(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_or_skip() {
+        let _ = OsCapturer::open();
+    }
+}

--- a/crates/sqyre-capture/src/x11_capture.rs
+++ b/crates/sqyre-capture/src/x11_capture.rs
@@ -16,8 +16,8 @@ use x11::xlib::{
 
 const ALLPLANES: u64 = !0;
 
-/// Shared X11 display connection (not Send across threads freely — mutex serializes).
-pub struct X11Capturer {
+/// Shared X11 display connection (public type [`OsCapturer`]; mutex serializes access).
+pub struct OsCapturer {
     inner: Mutex<X11State>,
 }
 
@@ -32,19 +32,19 @@ struct X11State {
 unsafe impl Send for X11State {}
 
 /// Process-wide capturer for UI offload (cloned via [`Arc`]; access serialized by inner Mutex).
-static SHARED_UI_CAPTURER: OnceLock<Result<Arc<X11Capturer>, String>> = OnceLock::new();
+static SHARED_UI_CAPTURER: OnceLock<Result<Arc<OsCapturer>, String>> = OnceLock::new();
 
 /// Shared capturer for UI-thread offload (preview tooltips, AutoPic, etc.).
-pub fn shared_capturer() -> Result<Arc<X11Capturer>, String> {
+pub fn shared_capturer() -> Result<Arc<OsCapturer>, String> {
     match SHARED_UI_CAPTURER
-        .get_or_init(|| X11Capturer::open().map(Arc::new).map_err(|e| e.to_string()))
+        .get_or_init(|| OsCapturer::open().map(Arc::new).map_err(|e| e.to_string()))
     {
         Ok(c) => Ok(Arc::clone(c)),
         Err(e) => Err(e.clone()),
     }
 }
 
-impl X11Capturer {
+impl OsCapturer {
     pub fn open() -> Result<Self, CaptureError> {
         unsafe {
             let display = XOpenDisplay(ptr::null());
@@ -215,7 +215,7 @@ impl Drop for X11State {
     }
 }
 
-impl ScreenCapturer for X11Capturer {
+impl ScreenCapturer for OsCapturer {
     fn capture_monitor(&mut self, display_index: i32) -> Result<RgbaImage, String> {
         if display_index != 0 {
             return Err(CaptureError::UnsupportedDisplay(display_index).into());
@@ -242,7 +242,7 @@ impl ScreenCapturer for X11Capturer {
 }
 
 /// [`ScreenCapturer`] over a shared [`Arc`] capturer (macro run thread).
-pub struct SharedRunCapturer(pub Arc<X11Capturer>);
+pub struct SharedRunCapturer(pub Arc<OsCapturer>);
 
 impl ScreenCapturer for SharedRunCapturer {
     fn capture_monitor(&mut self, display_index: i32) -> Result<RgbaImage, String> {
@@ -277,6 +277,6 @@ mod tests {
     #[test]
     fn open_or_skip() {
         // CI / headless: open may fail — that's ok.
-        let _ = X11Capturer::open();
+        let _ = OsCapturer::open();
     }
 }

--- a/crates/sqyre-capture/src/x11_focus.rs
+++ b/crates/sqyre-capture/src/x11_focus.rs
@@ -47,9 +47,9 @@ where
 
 /// Focus a top-level window by executable path + window title.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct X11WindowFocuser;
+pub struct OsWindowFocuser;
 
-impl WindowFocuser for X11WindowFocuser {
+impl WindowFocuser for OsWindowFocuser {
     fn focus(&self, process_path: &str, window_title: &str) -> Result<(), String> {
         activate_window(process_path, window_title)
     }

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -2,7 +2,9 @@
 
 ## Dev container (recommended)
 
-Open the repository in the dev container (`.devcontainer/`). It includes Rust 1.92, clang, Tesseract/Leptonica, X11 link deps, and AppImage packaging tools (`appimage-builder`, squashfs-tools).
+Open the repository in the dev container (`.devcontainer/`). It includes Rust 1.92, clang, Tesseract/Leptonica, X11 link deps, AppImage packaging tools (`appimage-builder`, squashfs-tools), and the **Docker CLI** (host daemon via socket) so `make windows` and AppImage Docker fallbacks work inside the container.
+
+Nested `docker run -v` mounts use the host path via `LOCAL_WORKSPACE_FOLDER` (`${localWorkspaceFolder}`). Rebuild the container after pulling that change so the env var is set.
 
 From the repo root:
 
@@ -16,6 +18,8 @@ make test       # cargo nextest (falls back to cargo test)
 make coverage   # llvm-cov HTML + lcov under target/coverage/
 make docs-media # regenerate docs/images screenshots
 make appimage   # bin/*.AppImage (Linux)
+make windows    # bin/sqyre.exe (Docker MinGW cross / native on Windows)
+make macos      # bin/sqyre (macOS host)
 make tessdata   # download eng.traineddata into assets/tessdata/
 ```
 
@@ -51,11 +55,13 @@ Build caches (all gitignored):
 | `run` | `cargo run -p sqyre-app` |
 | `docs-media` | Regenerate `docs/images/` screenshots |
 | `appimage` | `bin/Sqyre-*.AppImage` |
+| `windows` | `bin/sqyre.exe` (Docker MinGW cross on Linux; native on Windows) |
+| `macos` | `bin/sqyre` (release; macOS host only) |
 | `tessdata` | Tesseract trained data via `scripts/download-tessdata.sh` |
 
 Set `CARGO_FLAGS` for extra cargo args. Set `RELEASE_VERSION` (or write a `VERSION` file) before `make appimage` to stamp the AppImage name.
 
-CI builds and releases **Linux** binaries and AppImages only. Windows/macOS automation is not shipped yet.
+CI builds and releases **Linux** binaries and AppImages only. PRs also `cargo check` on Windows and macOS (Windows GDI capture; macOS capture still stubbed). On Linux/macOS hosts, `make windows` uses the MinGW cross image in [`scripts/windows/`](../scripts/windows/PACKAGING.md); `make macos` stays native. MSI/DMG packaging is not shipped yet.
 
 ---
 
@@ -64,6 +70,8 @@ CI builds and releases **Linux** binaries and AppImages only. Windows/macOS auto
 | Resource | Purpose |
 |----------|---------|
 | [.devcontainer/Dockerfile](../.devcontainer/Dockerfile) | Rust + Tesseract + AppImage tools |
+| [.devcontainer/devcontainer.json](../.devcontainer/devcontainer.json) | Docker-outside-of-Docker (CLI + host socket) for `make windows` |
+| [scripts/windows/Dockerfile](../scripts/windows/Dockerfile) | MinGW cross image for `make windows` on Linux |
 | [crates/sqyre-app/assets/icons/](../crates/sqyre-app/assets/icons/) | Brand icons (embedded SVG) |
 | [assets/tessdata/](../assets/tessdata/) | Optional local `eng.traineddata` fallback |
 

--- a/docs/RUST.md
+++ b/docs/RUST.md
@@ -1,6 +1,6 @@
 # Sqyre Rust workspace
 
-Cargo workspace at the repo root (egui + PureCV). **`make` / `./bin/sqyre` is the only shipped binary** (Linux).
+Cargo workspace at the repo root (egui + PureCV). **`make` / `./bin/sqyre` is the only shipped release binary** (Linux). Windows/macOS build in CI as compile-checks; releases stay Linux-only for now.
 
 ## Layout
 
@@ -25,7 +25,7 @@ Cargo workspace at the repo root (egui + PureCV). **`make` / `./bin/sqyre` is th
 | `sqyre-match` | `TM_CCOEFF_NORMED` + mask + peak/dedup |
 | `sqyre-vision` | RGB load, match façade, find-pixel, OCR preprocess / Tesseract |
 | `sqyre-input` | `AutomationBackend` (rustautogui lite + arboard) |
-| `sqyre-capture` | `ScreenCapturer` (Linux X11 absolute rects) |
+| `sqyre-capture` | `ScreenCapturer` (`OsCapturer`: Linux X11, Windows GDI, macOS stub) |
 | `sqyre-hotkeys` | Esc stop / failsafe (`hooks` feature; stub default) |
 | `sqyre-app` | egui shell; Run/Stop macros |
 
@@ -33,13 +33,15 @@ Cargo workspace at the repo root (egui + PureCV). **`make` / `./bin/sqyre` is th
 
 Requires **Rust ≥ 1.92** (egui 0.34 / PureCV). The repo pins `1.92.0` via [`rust-toolchain.toml`](../rust-toolchain.toml); the `.devcontainer` matches that plus clang/Tesseract for OCR.
 
-Linux automation/capture need X11 (`libx11-dev`, `libxtst-dev`).
+Linux automation/capture need X11 (`libx11-dev`, `libxtst-dev`). Windows capture uses GDI (`windows` crate); macOS capture is still stubbed.
 
 From the repo root:
 
 ```bash
 make                 # ./bin/sqyre (debug)
 make release         # ./bin/sqyre (release)
+make windows         # ./bin/sqyre.exe (Docker MinGW cross / native on Windows)
+make macos           # ./bin/sqyre (macOS host)
 make check           # fmt + clippy (-D warnings) + cargo deny
 make test            # cargo nextest (falls back to cargo test)
 make coverage        # llvm-cov HTML + lcov under target/coverage/
@@ -62,6 +64,6 @@ Do not expect X11 inside the container — build there, run the binary on the ho
 
 Host binary: `./bin/sqyre` after `make`, or `./target/debug/sqyre` from cargo. Esc stops a running macro; Esc+Ctrl+Shift exits (failsafe).
 
-Still improving: Wayland, Windows/macOS automation + capture. CI releases Linux only.
+Still improving: Wayland, macOS capture, Windows/macOS window focus + releases. CI releases Linux only; Win/macOS `cargo check` on PRs.
 
 OCR uses Tesseract (`leptess`). Override tessdata with `SQYRE_TESSDATA` if needed (dev fallback: `assets/tessdata`).

--- a/scripts/lib/docker-host-path.sh
+++ b/scripts/lib/docker-host-path.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Resolve the Docker-daemon-visible path for REPO_ROOT (docker-outside-of-docker).
+#
+# Nested `docker run -v "$REPO_ROOT:..."` uses the host daemon. Inside a
+# devcontainer, REPO_ROOT is often /workspace, which does not exist on the host.
+#
+# Prefers LOCAL_WORKSPACE_FOLDER (set from ${localWorkspaceFolder} in
+# .devcontainer/devcontainer.json), then docker inspect of this container's
+# bind mount, then REPO_ROOT (bare-metal / CI).
+#
+# Requires: REPO_ROOT. Sets/exports DOCKER_HOST_REPO_ROOT.
+
+_docker_host_path_lib="${BASH_SOURCE[0]:-$0}"
+
+if [ -z "${REPO_ROOT:-}" ]; then
+  echo "docker-host-path.sh: REPO_ROOT is not set (source repo-root.sh first)" >&2
+  unset _docker_host_path_lib
+  return 1 2>/dev/null || exit 1
+fi
+
+_docker_host_repo_root_resolve() {
+  if [ -n "${LOCAL_WORKSPACE_FOLDER:-}" ]; then
+    printf '%s\n' "$LOCAL_WORKSPACE_FOLDER"
+    return 0
+  fi
+
+  # Host (or any env where the path is already daemon-visible).
+  if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
+    printf '%s\n' "$REPO_ROOT"
+    return 0
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    local cid src
+    cid="$(hostname 2>/dev/null || true)"
+    if [ -n "$cid" ]; then
+      src="$(docker inspect -f \
+        '{{range .Mounts}}{{if eq .Destination "'"$REPO_ROOT"'"}}{{.Source}}{{end}}{{end}}' \
+        "$cid" 2>/dev/null || true)"
+      if [ -z "$src" ]; then
+        src="$(docker inspect -f \
+          '{{range .Mounts}}{{if eq .Destination "/workspace"}}{{.Source}}{{end}}{{end}}' \
+          "$cid" 2>/dev/null || true)"
+      fi
+      if [ -n "$src" ]; then
+        printf '%s\n' "$src"
+        return 0
+      fi
+    fi
+  fi
+
+  printf '%s\n' "$REPO_ROOT"
+}
+
+DOCKER_HOST_REPO_ROOT="$(_docker_host_repo_root_resolve)"
+export DOCKER_HOST_REPO_ROOT
+
+# Map a path under REPO_ROOT to the host path for docker -v / build contexts.
+docker_host_path() {
+  local p="${1:?docker_host_path: path required}"
+  case "$p" in
+    "$REPO_ROOT"|"$REPO_ROOT"/*)
+      printf '%s\n' "${DOCKER_HOST_REPO_ROOT}${p#"$REPO_ROOT"}"
+      ;;
+    *)
+      printf '%s\n' "$p"
+      ;;
+  esac
+}
+
+unset _docker_host_path_lib
+return 0 2>/dev/null || exit 0

--- a/scripts/linux/packaging/appimage/build-appimage.sh
+++ b/scripts/linux/packaging/appimage/build-appimage.sh
@@ -11,6 +11,8 @@ cd "$SCRIPT_DIR"
 
 # shellcheck source=scripts/lib/repo-root.sh
 . "$SCRIPT_DIR/../../../lib/repo-root.sh"
+# shellcheck source=scripts/lib/docker-host-path.sh
+. "$SCRIPT_DIR/../../../lib/docker-host-path.sh"
 
 have_cmd() { command -v "$1" >/dev/null 2>&1; }
 
@@ -125,7 +127,7 @@ run_docker() {
   echo "Building AppImage v${APP_VERSION} (docker: $IMAGE, CARGO_HOME=$CARGO_HOME_REL)…"
   docker run --rm \
     -u "$(id -u):$(id -g)" \
-    -v "$REPO_ROOT:/workspace" -w /workspace \
+    -v "$(docker_host_path "$REPO_ROOT"):/workspace" -w /workspace \
     -e HOME=/tmp \
     -e "CARGO_HOME=/workspace/$CARGO_HOME_REL" \
     -e CARGO_TARGET_DIR=/workspace/target \

--- a/scripts/windows/Dockerfile
+++ b/scripts/windows/Dockerfile
@@ -1,0 +1,71 @@
+# Sqyre Windows cross-compile image (Linux → x86_64-pc-windows-gnu).
+# Static MinGW zlib/libpng/libjpeg/leptonica/tesseract — adapted from the former
+# Go fyne-cross Dockerfile.windows-amd64 (debian bookworm + cmake staticbuild).
+FROM debian:bookworm-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=1.92.0
+ARG MINGW_PREFIX=/usr/local/mingw64-static
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git \
+    build-essential cmake \
+    gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 \
+    gcc-mingw-w64-x86-64-posix g++-mingw-w64-x86-64-posix \
+    pkg-config \
+    clang libclang-dev \
+    lld \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV MINGW_HOST=x86_64-w64-mingw32 \
+    MINGW_PREFIX=${MINGW_PREFIX}
+
+COPY build-mingw-deps.sh /tmp/build-mingw-deps.sh
+RUN sed -i 's/\r$//' /tmp/build-mingw-deps.sh \
+ && chmod +x /tmp/build-mingw-deps.sh \
+ && bash /tmp/build-mingw-deps.sh "${MINGW_PREFIX}" \
+ && rm -f /tmp/build-mingw-deps.sh
+
+# Unversioned names for -lleptonica / -ltesseract (same as Go image).
+RUN set -eux \
+ && cd "${MINGW_PREFIX}/lib" \
+ && if [ ! -e libleptonica.a ]; then \
+      f=$(ls libleptonica-*.a liblept.a 2>/dev/null | head -1); \
+      [ -n "$f" ] && ln -sf "$f" libleptonica.a && ln -sf "$f" liblept.a; \
+    fi \
+ && if [ ! -e libtesseract.a ]; then \
+      f=$(ls libtesseract[0-9]*.a 2>/dev/null | head -1); \
+      [ -n "$f" ] && ln -sf "$f" libtesseract.a; \
+    fi \
+ && ls -la liblept* libtesseract* libpng* libz* libjpeg* 2>/dev/null || true
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH="/usr/local/cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+        --default-toolchain "${RUST_VERSION}" \
+        --profile minimal \
+        --target x86_64-pc-windows-gnu \
+    && chmod -R a+rwX /usr/local/rustup /usr/local/cargo \
+    && rustc --version && rustup target list --installed
+
+COPY mingw-lld-link.sh /usr/local/bin/mingw-lld-link
+RUN sed -i 's/\r$//' /usr/local/bin/mingw-lld-link && chmod 755 /usr/local/bin/mingw-lld-link \
+ && mkdir -p /usr/local/libexec/mingw-rust-lld \
+ && ln -sfn /usr/local/cargo/bin/rust-lld /usr/local/libexec/mingw-rust-lld/ld.lld \
+ && ln -sfn /usr/local/cargo/bin/rust-lld /usr/local/libexec/mingw-rust-lld/x86_64-w64-mingw32-ld.lld \
+ && ln -sfn /usr/local/cargo/bin/rust-lld /usr/local/libexec/mingw-rust-lld/ld \
+ && chmod -R a+rX /usr/local/libexec/mingw-rust-lld
+
+# rust-lld wrapper + MinGW lib paths (LLVM 14 system lld rejects Rust 1.92 COFF).
+ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=mingw-lld-link \
+    CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc-posix \
+    CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++-posix \
+    AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-ar \
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    PKG_CONFIG_PATH=${MINGW_PREFIX}/lib/pkgconfig \
+    PKG_CONFIG_LIBDIR=${MINGW_PREFIX}/lib/pkgconfig \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu=--sysroot=/usr/x86_64-w64-mingw32 \
+    RUSTFLAGS="-L${MINGW_PREFIX}/lib -C link-arg=-lpng16 -C link-arg=-ljpeg -C link-arg=-lz -C link-arg=-lstdc++ -C link-arg=-lm -C link-arg=-lmsvcrt"
+
+WORKDIR /workspace

--- a/scripts/windows/PACKAGING.md
+++ b/scripts/windows/PACKAGING.md
@@ -1,0 +1,26 @@
+# Windows packaging / cross-build
+
+Sqyre ships a bare `sqyre.exe` (no MSI). Build it with:
+
+```bash
+make windows          # Docker MinGW cross from Linux/macOS; native on Windows
+```
+
+## Cross image
+
+[`Dockerfile`](./Dockerfile) (based on the former Go fyne-cross Windows image) produces `sqyre-windows-cross:latest` with:
+
+- Debian bookworm + MinGW-w64 posix
+- Rust `1.92` + `x86_64-pc-windows-gnu`
+- Static zlib / libpng / libjpeg-turbo / leptonica / tesseract under `/usr/local/mingw64-static`
+- Linker: `mingw-lld-link` (MinGW g++ driver + `rust-lld` via `-fuse-ld=lld`) — bookworm GNU ld segfaults on Rust 1.92 COFF
+
+First `make windows` on Linux builds the image (slow once). Later runs reuse it and cache crates under `.cache/cargo` (or `.cargo-home` when Make exports that).
+
+| Env | Role |
+|-----|------|
+| `SQYRE_WINDOWS_IMAGE` | Override image tag |
+| `SQYRE_WINDOWS_FORCE_NATIVE=1` | Native Windows only (fail on Linux) |
+| `CARGO_FLAGS` | Extra cargo args |
+
+Output: `bin/sqyre.exe`.

--- a/scripts/windows/build-mingw-deps.sh
+++ b/scripts/windows/build-mingw-deps.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Build static zlib/libpng/libjpeg/leptonica/tesseract for MinGW x86_64.
+# Adapted from the former Go fyne-cross scripts/windows/docker/build-static-libs.sh
+# (OpenCV omitted — Rust uses purecv).
+#
+# Run inside the Windows cross image build. Installs to DESTDIR.
+set -euo pipefail
+set -x
+
+DESTDIR="${1:-/usr/local/mingw64-static}"
+BUILD_DIR="${BUILD_DIR:-/tmp/staticbuild}"
+export PKG_CONFIG_PATH="$DESTDIR/lib/pkgconfig"
+export PATH="$DESTDIR/bin:$PATH"
+
+CC=x86_64-w64-mingw32-gcc-posix
+CXX=x86_64-w64-mingw32-g++-posix
+command -v "$CC" >/dev/null 2>&1 || CC=x86_64-w64-mingw32-gcc
+command -v "$CXX" >/dev/null 2>&1 || CXX=x86_64-w64-mingw32-g++
+export CC CXX
+
+ZLIB_VER="${ZLIB_VER:-1.3.1}"
+LIBPNG_VER="${LIBPNG_VER:-1.6.43}"
+LIBJPEG_VER="${LIBJPEG_VER:-2.1.5.1}"
+LEPTONICA_VER="${LEPTONICA_VER:-1.83.1}"
+TESSERACT_VER="${TESSERACT_VER:-5.5.0}"
+
+mkdir -p "$DESTDIR" "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+fetch() {
+  local url="$1" out="$2"
+  curl -f -sL "$url" -o "$out"
+}
+
+echo "=== zlib ${ZLIB_VER} ==="
+fetch "https://github.com/madler/zlib/archive/refs/tags/v${ZLIB_VER}.tar.gz" zlib.tar.gz
+rm -rf "zlib-${ZLIB_VER}"
+tar xzf zlib.tar.gz
+(
+  cd "zlib-${ZLIB_VER}"
+  cmake -B build -G "Unix Makefiles" \
+    -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_INSTALL_PREFIX="$DESTDIR" \
+    -DZLIB_BUILD_SHARED=OFF -DZLIB_BUILD_STATIC=ON
+  cmake --build build -j"$(nproc)"
+  cmake --install build
+  # Dependents look for -lz; cmake may install libzlibstatic.a
+  if [ -f "$DESTDIR/lib/libzlibstatic.a" ] && [ ! -f "$DESTDIR/lib/libz.a" ]; then
+    ln -sf libzlibstatic.a "$DESTDIR/lib/libz.a"
+  fi
+)
+
+echo "=== libpng ${LIBPNG_VER} ==="
+fetch "https://sourceforge.net/projects/libpng/files/libpng16/${LIBPNG_VER}/libpng-${LIBPNG_VER}.tar.gz/download" \
+  libpng.tar.gz
+rm -rf "libpng-${LIBPNG_VER}"
+tar xzf libpng.tar.gz
+(
+  cd "libpng-${LIBPNG_VER}"
+  export CPPFLAGS="-I$DESTDIR/include"
+  export LDFLAGS="-L$DESTDIR/lib"
+  ./configure --host=x86_64-w64-mingw32 --prefix="$DESTDIR" \
+    --enable-static --disable-shared
+  make -j"$(nproc)"
+  make install
+)
+unset CPPFLAGS LDFLAGS
+
+echo "=== libjpeg-turbo ${LIBJPEG_VER} ==="
+fetch "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/${LIBJPEG_VER}.tar.gz" \
+  jpeg.tar.gz
+rm -rf "libjpeg-turbo-${LIBJPEG_VER}"
+tar xzf jpeg.tar.gz
+(
+  cd "libjpeg-turbo-${LIBJPEG_VER}"
+  cmake -B build -G "Unix Makefiles" \
+    -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
+    -DCMAKE_C_COMPILER="$CC" -DCMAKE_INSTALL_PREFIX="$DESTDIR" \
+    -DENABLE_SHARED=OFF -DENABLE_STATIC=ON \
+    -DWITH_SIMD=OFF
+  cmake --build build -j"$(nproc)"
+  cmake --install build
+)
+
+# Shared cmake cross flags (from former Go build-static-libs.sh).
+# CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY avoids running Windows test exes.
+# shellcheck disable=SC2089
+CMAKE_CROSS="-DCMAKE_SYSTEM_NAME=Windows \
+  -DCMAKE_SYSTEM_PROCESSOR=AMD64 \
+  -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_FIND_ROOT_PATH=$DESTDIR \
+  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+  -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+  -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY \
+  -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
+
+echo "=== leptonica ${LEPTONICA_VER} ==="
+fetch "https://github.com/DanBloomberg/leptonica/archive/refs/tags/${LEPTONICA_VER}.tar.gz" \
+  leptonica.tar.gz
+rm -rf "leptonica-${LEPTONICA_VER}"
+tar xzf leptonica.tar.gz
+(
+  cd "leptonica-${LEPTONICA_VER}"
+  mkdir build && cd build
+  # Override false-positive open_memstream/fmemopen detection under STATIC_LIBRARY try_compile.
+  # shellcheck disable=SC2090
+  cmake .. $CMAKE_CROSS \
+    -DCMAKE_INSTALL_PREFIX="$DESTDIR" -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_PREFIX_PATH="$DESTDIR" \
+    -DSW_BUILD=OFF \
+    -DHAVE_FMEMOPEN=0 -DHAVE_OPEN_MEMSTREAM=0
+  make -j"$(nproc)"
+  make install
+)
+(
+  cd "$DESTDIR/lib"
+  for f in libleptonica-*.a libleptonica.a liblept.a; do
+    if [ -f "$f" ]; then
+      ln -sf "$f" libleptonica.a
+      ln -sf "$f" liblept.a
+      break
+    fi
+  done
+  ls -la "$DESTDIR/lib/liblept"*
+)
+
+# Minimal LeptonicaConfig.cmake — auto-generated configs crash cmake when
+# Tesseract consumes them during MinGW cross (same fix as Go pipeline).
+LEPT_CMAKE_DIR="$DESTDIR/lib/cmake/leptonica"
+rm -rf "$LEPT_CMAKE_DIR"
+mkdir -p "$LEPT_CMAKE_DIR"
+cat > "$LEPT_CMAKE_DIR/LeptonicaConfig.cmake" << 'LEPTCFG'
+set(Leptonica_FOUND TRUE)
+set(Leptonica_VERSION "1.83.1")
+set(Leptonica_VERSION_MAJOR 1)
+set(Leptonica_VERSION_MINOR 83)
+set(Leptonica_VERSION_PATCH 1)
+get_filename_component(_lept_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+set(Leptonica_INCLUDE_DIRS "${_lept_prefix}/include" "${_lept_prefix}/include/leptonica")
+set(LEPTONICA_INCLUDE_DIRS "${Leptonica_INCLUDE_DIRS}")
+find_library(Leptonica_LIBRARY
+  NAMES leptonica leptonica-1.83.1 lept
+  PATHS "${_lept_prefix}/lib"
+  NO_DEFAULT_PATH)
+set(Leptonica_LIBRARIES "${Leptonica_LIBRARY}")
+set(LEPTONICA_LIBRARIES "${Leptonica_LIBRARY}")
+if(NOT TARGET leptonica)
+  add_library(leptonica STATIC IMPORTED)
+  set_target_properties(leptonica PROPERTIES
+    IMPORTED_LOCATION "${Leptonica_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Leptonica_INCLUDE_DIRS}"
+  )
+endif()
+unset(_lept_prefix)
+LEPTCFG
+cat > "$LEPT_CMAKE_DIR/LeptonicaConfig-version.cmake" << 'LEPTVER'
+set(PACKAGE_VERSION "1.83.1")
+if("${PACKAGE_FIND_VERSION}" VERSION_GREATER PACKAGE_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if("${PACKAGE_FIND_VERSION}" VERSION_EQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()
+LEPTVER
+
+# pkg-config for leptess (leptonica-sys probes "lept")
+mkdir -p "$DESTDIR/lib/pkgconfig"
+if [ ! -f "$DESTDIR/lib/pkgconfig/lept.pc" ]; then
+  cat > "$DESTDIR/lib/pkgconfig/lept.pc" << EOF
+prefix=$DESTDIR
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: lept
+Description: Leptonica image processing library
+Version: ${LEPTONICA_VER}
+Libs: -L\${libdir} -lleptonica
+Libs.private: -lpng16 -ljpeg -lz
+Cflags: -I\${includedir}/leptonica
+EOF
+fi
+
+echo "=== tesseract ${TESSERACT_VER} ==="
+fetch "https://github.com/tesseract-ocr/tesseract/archive/refs/tags/${TESSERACT_VER}.tar.gz" \
+  tesseract.tar.gz
+rm -rf "tesseract-${TESSERACT_VER}"
+tar xzf tesseract.tar.gz
+(
+  cd "tesseract-${TESSERACT_VER}"
+  mkdir build && cd build
+  # shellcheck disable=SC2090
+  cmake .. $CMAKE_CROSS \
+    -DCMAKE_INSTALL_PREFIX="$DESTDIR" -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_PREFIX_PATH="$DESTDIR" \
+    -DLeptonica_DIR="$DESTDIR/lib/cmake/leptonica" \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DSW_BUILD=OFF \
+    -DBUILD_TRAINING_TOOLS=OFF -DBUILD_TESTS=OFF \
+    -DDISABLE_CURL=ON -DDISABLE_ARCHIVE=ON \
+    -DGRAPHICS_DISABLED=ON
+  # Library only — skip CLI (Ws2_32 / optional image deps).
+  cmake --build . -j"$(nproc)" --target libtesseract
+  cp libtesseract*.a "$DESTDIR/lib/"
+  (
+    cd "$DESTDIR/lib"
+    for f in libtesseract[0-9]*.a libtesseract.a; do
+      if [ -f "$f" ]; then
+        ln -sf "$f" libtesseract.a
+        break
+      fi
+    done
+  )
+  mkdir -p "$DESTDIR/include/tesseract"
+  cp ../include/tesseract/*.h "$DESTDIR/include/tesseract/"
+  find include -name '*.h' -exec cp {} "$DESTDIR/include/tesseract/" \; 2>/dev/null || true
+  mkdir -p "$DESTDIR/lib/pkgconfig"
+  if [ -f tesseract.pc ]; then
+    cp tesseract.pc "$DESTDIR/lib/pkgconfig/"
+  else
+    cat > "$DESTDIR/lib/pkgconfig/tesseract.pc" << EOF
+prefix=$DESTDIR
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: tesseract
+Description: Tesseract OCR
+Version: ${TESSERACT_VER}
+Requires: lept
+Libs: -L\${libdir} -ltesseract
+Libs.private: -lstdc++
+Cflags: -I\${includedir}
+EOF
+  fi
+)
+
+# Ensure x86_64-w64-mingw32-pkg-config can see our .pc files when PREFIX differs.
+"${CC%-gcc*}"-pkg-config --exists tesseract || true
+"${CC%-gcc*}"-pkg-config --exists lept || PKG_CONFIG_PATH="$DESTDIR/lib/pkgconfig" \
+  pkg-config --exists lept
+PKG_CONFIG_PATH="$DESTDIR/lib/pkgconfig" pkg-config --modversion tesseract
+PKG_CONFIG_PATH="$DESTDIR/lib/pkgconfig" pkg-config --libs --static tesseract
+
+echo "=== Static MinGW OCR deps installed under ${DESTDIR} ==="
+ls -la "$DESTDIR/lib/libtesseract"* "$DESTDIR/lib/liblept"* "$DESTDIR/lib/libpng"* "$DESTDIR/lib/libz"* "$DESTDIR/lib/libjpeg"* 2>/dev/null || true
+rm -rf "$BUILD_DIR"

--- a/scripts/windows/build.sh
+++ b/scripts/windows/build.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Build Sqyre for Windows (x86_64).
+#
+# - On Windows: native `cargo build --release` → bin/sqyre.exe
+# - Elsewhere: Docker MinGW cross image → bin/sqyre.exe
+#
+# Env:
+#   SQYRE_WINDOWS_IMAGE          image tag (default: sqyre-windows-cross:latest)
+#   SQYRE_WINDOWS_FORCE_NATIVE=1 require native Windows tools (no Docker)
+#   CARGO_FLAGS                  extra cargo args
+#   CARGO_HOME / CARGO_TARGET_DIR  optional cache paths (docker mounts in-repo)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/repo-root.sh
+. "$SCRIPT_DIR/../lib/repo-root.sh"
+# shellcheck source=scripts/lib/docker-host-path.sh
+. "$SCRIPT_DIR/../lib/docker-host-path.sh"
+
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+is_windows_host() {
+  case "$(uname -s 2>/dev/null || true)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+  esac
+  [ "${OS:-}" = "Windows_NT" ]
+}
+
+need_native() {
+  have_cmd cargo
+}
+
+run_native() {
+  local target_dir="${CARGO_TARGET_DIR:-$REPO_ROOT/target}"
+  mkdir -p "$REPO_ROOT/bin"
+  echo "Building Windows release (native)…"
+  (
+    cd "$REPO_ROOT"
+    # shellcheck disable=SC2086
+    cargo build -p sqyre-app --release ${CARGO_FLAGS:-}
+  )
+  local src
+  if [ -f "$target_dir/release/sqyre.exe" ]; then
+    src="$target_dir/release/sqyre.exe"
+  elif [ -f "$target_dir/x86_64-pc-windows-gnu/release/sqyre.exe" ]; then
+    src="$target_dir/x86_64-pc-windows-gnu/release/sqyre.exe"
+  else
+    echo "Built binary not found under $target_dir" >&2
+    exit 1
+  fi
+  cp -f "$src" "$REPO_ROOT/bin/sqyre.exe"
+  echo "Windows binary: $REPO_ROOT/bin/sqyre.exe"
+}
+
+run_docker() {
+  if ! have_cmd docker; then
+    echo "Windows cross-build needs Docker on non-Windows hosts." >&2
+    echo "Install Docker, or build on Windows with: make windows" >&2
+    exit 1
+  fi
+
+  local image="${SQYRE_WINDOWS_IMAGE:-sqyre-windows-cross:latest}"
+  local dockerfile="$SCRIPT_DIR/Dockerfile"
+  local host_repo
+  host_repo="$(docker_host_path "$REPO_ROOT")"
+
+  if ! docker image inspect "$image" >/dev/null 2>&1; then
+    echo "Building Docker image $image (one-time; compiles MinGW Tesseract)…"
+    docker build -f "$dockerfile" -t "$image" "$SCRIPT_DIR"
+  fi
+
+  local cargo_home_rel=".cache/cargo"
+  if [ -n "${CARGO_HOME:-}" ]; then
+    case "$CARGO_HOME" in
+      "$REPO_ROOT"/*) cargo_home_rel="${CARGO_HOME#"$REPO_ROOT"/}" ;;
+    esac
+  elif [ -x "$REPO_ROOT/.cargo-home/bin/cargo" ]; then
+    cargo_home_rel=".cargo-home"
+  fi
+  mkdir -p "$REPO_ROOT/$cargo_home_rel" "$REPO_ROOT/target" "$REPO_ROOT/bin"
+
+  echo "Building Windows release (docker: $image, CARGO_HOME=$cargo_home_rel)…"
+  docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "$host_repo:/workspace" -w /workspace \
+    -e HOME=/tmp \
+    -e "CARGO_HOME=/workspace/$cargo_home_rel" \
+    -e CARGO_TARGET_DIR=/workspace/target \
+    -e RUSTUP_HOME=/usr/local/rustup \
+    -e PATH=/usr/local/cargo/bin:/usr/local/bin:/usr/bin:/bin \
+    -e "CARGO_FLAGS=${CARGO_FLAGS:-}" \
+    "$image" \
+    bash -c 'set -euo pipefail
+      cargo build -p sqyre-app --release --target x86_64-pc-windows-gnu ${CARGO_FLAGS:-}
+      cp -f target/x86_64-pc-windows-gnu/release/sqyre.exe /workspace/bin/sqyre.exe
+    '
+
+  if [ ! -f "$REPO_ROOT/bin/sqyre.exe" ]; then
+    echo "Docker Windows build finished but bin/sqyre.exe is missing" >&2
+    exit 1
+  fi
+  echo "Windows binary: $REPO_ROOT/bin/sqyre.exe"
+}
+
+if [ "${SQYRE_WINDOWS_FORCE_NATIVE:-}" = "1" ]; then
+  if ! is_windows_host; then
+    echo "SQYRE_WINDOWS_FORCE_NATIVE=1 requires a Windows host." >&2
+    exit 1
+  fi
+  if ! need_native; then
+    echo "SQYRE_WINDOWS_FORCE_NATIVE=1 but cargo is missing." >&2
+    exit 1
+  fi
+  run_native
+elif is_windows_host; then
+  run_native
+else
+  run_docker
+fi

--- a/scripts/windows/mingw-lld-link.sh
+++ b/scripts/windows/mingw-lld-link.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# MinGW g++ driver + rust-lld (as ld.lld). Bookworm GNU ld segfaults on Rust 1.92 COFF.
+set -e
+BDIR="${MINGW_LLD_BDIR:-/usr/local/libexec/mingw-rust-lld}"
+exec x86_64-w64-mingw32-g++-posix -B"$BDIR" -fuse-ld=lld "$@"


### PR DESCRIPTION
…iner.

Enable docker-outside-of-docker with Docker CE (avoid blocked Moby GPG), pass the host workspace path for nested volume mounts, and ship MinGW cross-build plus Windows GDI capture with CI compile-checks.