### PR TITLE
Add Cloud Agent development environment for Sqyre

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Sqyre (Rust)",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for Sqyre.
+# Installs the native system dependencies (Tesseract/Leptonica, X11, clang)
+# that the Rust workspace links against, then warms the build cache by
+# compiling the GUI binary. Safe to re-run; apt is a no-op once satisfied
+# and cargo builds incrementally.
+set -euo pipefail
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+$SUDO apt-get update -qq
+$SUDO apt-get install -y --no-install-recommends \
+  build-essential pkg-config \
+  clang libclang-dev \
+  tesseract-ocr tesseract-ocr-eng libtesseract-dev libleptonica-dev \
+  libx11-dev libxkbcommon-dev libxkbcommon-x11-dev \
+  libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
+  libwayland-dev libegl1-mesa-dev libdbus-1-dev \
+  libfontconfig1-dev libasound2-dev \
+  mesa-vulkan-drivers libvulkan1 \
+  libxtst-dev libxrandr-dev libxinerama-dev libxi-dev
+
+# Warm the workspace build cache and validate the native link chain.
+cargo build -p sqyre-app --locked


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a Cloud Agent environment configuration so Sqyre builds, tests, and runs out of the box in Cursor Cloud Agents.

- `.cursor/environment.json` — names the environment and runs the install script.
- `.cursor/install.sh` — idempotent bootstrap that apt-installs the native link dependencies (Tesseract/Leptonica, X11/XCB, Wayland/EGL, clang, ALSA, Vulkan/Mesa) and warms the workspace build cache with `cargo build -p sqyre-app --locked`.

The base image already ships Rust 1.92 (the workspace minimum), so only the system libraries and a cache warm are needed. Dependency choices mirror the existing `.devcontainer/Dockerfile`.

## Validation (on this VM)

- `cargo build -p sqyre-app` — succeeded.
- `cargo test --workspace` — all suites passed (~478 tests), including the Tesseract OCR golden and headless wgpu docs-screenshot tests.
- `install.sh` re-run — apt no-op, incremental cargo (idempotent).
- Launched `./bin/sqyre` on the X11 display and drove the macro editor end-to-end: opened the categorized **Add Action** picker, added a **Wait** action, and confirmed the macro tree updated — no code execution triggered.

[Sqyre Add Action picker](https://cursor.com/agents/bc-4e32ed00-65c4-48ed-abcd-268b322a3d55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsqyre_02_add_action_picker.webp)
[Sqyre macro tree with Wait node](https://cursor.com/agents/bc-4e32ed00-65c4-48ed-abcd-268b322a3d55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsqyre_04_wait_node_added.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e32ed00-65c4-48ed-abcd-268b322a3d55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e32ed00-65c4-48ed-abcd-268b322a3d55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

